### PR TITLE
Update minVersionName in Production + Staging Environments to 2.0.0

### DIFF
--- a/nations_version.json
+++ b/nations_version.json
@@ -1,8 +1,8 @@
 {
   "co.pactplatform.nations.staging": {
-    "minVersionName": "0.1.0"
+    "minVersionName": "2.0.0"
   },
   "co.pactplatform.nations.production": {
-    "minVersionName": "0.1.0"
+    "minVersionName": "2.0.0"
   }
 }


### PR DESCRIPTION
Updated Siren minVersionName in staging and production environments to 2.0.0 for Nations Servicing Module release. 
Coordinated deployment with Backend.