### PR TITLE
Updating minVersionName for Pact D2C App to 2.3.0

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "com.martingale.pact": {
-    "minVersionName": "2.2.0"
+    "minVersionName": "2.3.0"
   }
 }


### PR DESCRIPTION
Forced update to:
- Phase-out Manatee Works SDK.
- Update Submission Confirmation screen, removing 24 hrs callback guarantee.